### PR TITLE
WHS-1791 Add apidoc refs to static pages (exported PDFs in Box)

### DIFF
--- a/src/pages/usage/getting-started.md
+++ b/src/pages/usage/getting-started.md
@@ -6,7 +6,7 @@ slug: getting-started
 toc: true
 ---
 
-The ACD service provides a robust set of REST APIs to generate clinical annotations over text and interact with persisted analytic artifacts.  To get started using the ACD service, see the [IBM Cloud API docs](https://cloud.ibm.com/apidocs/wh-acd) and examples.  The ACD Service REST APIs can be called directly or with the [IBM Watson Annotator for Clinical Data Software Development Kits (SDKs)](https://ibm.github.io/acd-containers/usage/sdks).
+The ACD service provides a robust set of REST APIs to generate clinical annotations over text and interact with persisted analytic artifacts.  To get started using the ACD service, see the [IBM Cloud API docs](https://cloud.ibm.com/apidocs/wh-acd) and examples. (Note that you must be signed in to IBM Cloud to see the docs.) Exported PDF versions of documentation for [Curl](https://ibm.box.com/shared/static/jnxqr0l48viqgwvkzw2v46eu4191wgvx.pdf), [Python](https://ibm.box.com/shared/static/40tvtuhcn0hmui99fb3jc2vh0pr1t7e2.pdf) and [Java](https://ibm.box.com/shared/static/mwna0rfmld0ybess2z4qj29azf9ys9ym.pdf) are also available. The ACD Service REST APIs can be called directly or with the [IBM Watson Annotator for Clinical Data Software Development Kits (SDKs)](https://ibm.github.io/acd-containers/usage/sdks).
 
 ### Deploying and updating the ACD-provided cartridges
 

--- a/src/pages/usage/sdks.md
+++ b/src/pages/usage/sdks.md
@@ -6,7 +6,7 @@ slug: sdks
 toc: true
 ---
 
-IBM Watson Annotator for Clinical Data has software development kits (SDK) in multiple languages for interacting with the ACD Service REST APIs.
+IBM Watson Annotator for Clinical Data has software development kits (SDK) in multiple languages for interacting with the ACD Service REST APIs, or to directly call the APIs, see the examples in the exported PDF documentation for [Curl](https://ibm.box.com/shared/static/jnxqr0l48viqgwvkzw2v46eu4191wgvx.pdf).
 
 To authenticate to IBM Watson Annotator for Clinical Data Container Edition, you pass a **bearer token** in the credentials.  If you have provided secure access to your ACD service instance via the Openshift OAuth service (see [Managing Access to ACD](https://ibm.github.io/acd-containers/security/manage-access/)), you will use the token that you created on the service account as your bearer token.  For access to an unsecured ACD service instance, the bearer token used for the credentials can be a dummy token.  
 
@@ -15,12 +15,10 @@ To authenticate to IBM Watson Annotator for Clinical Data Container Edition, you
 Find details about installing and using the SDKs.
 
 - [Java SDK](https://github.com/IBM/whcs-java-sdk)
+  - See the [IBM Cloud API docs](https://cloud.ibm.com/apidocs/wh-acd) (or an exported PDF version for [Java](https://ibm.box.com/shared/static/mwna0rfmld0ybess2z4qj29azf9ys9ym.pdf)) for examples. See also the Java SDK [javadoc](https://ibm.github.io/whcs-java-sdk/docs/latest/).
 
 - [Python SDK](https://github.com/IBM/whcs-python-sdk)
-
-- [Node SDK](https://github.com/IBM/whcs-node-sdk)
-
-- [Go SDK](https://github.com/IBM/whcs-go-sdk)
+  - See the [IBM Cloud API docs](https://cloud.ibm.com/apidocs/wh-acd) (or an exported PDF version for [Python](https://ibm.box.com/shared/static/40tvtuhcn0hmui99fb3jc2vh0pr1t7e2.pdf)) for examples.
 
 ## Examples
 
@@ -88,86 +86,4 @@ acd_service = acd.AnnotatorForClinicalDataV1(
     )
 acd_service.set_service_url({url})
 acd_service.set_disable_ssl_verification(True)
-```
-
-### Node SDK
-
-#### Authentication
-
-```
-const AnnotatorForClinicalDataAcdV1 = require('ibm-whcs-services/annotator-for-clinical-data/v1');
-const core = require('ibm-cloud-sdk-core');
-const { BearerTokenAuthenticator } = core;
-
-const acdService = new AnnotatorForClinicalDataAcdV1({
-  version: '{version}',
-  authenticator: new BearerTokenAuthenticator({
-    bearerToken: '{token}'
-    }),
-  serviceUrl: '{url}'
-});
-```
-
-#### Authentication and Disabling SSL Verification (not recommended)
-
-```
-const AnnotatorForClinicalDataAcdV1 = require('ibm-whcs-services/annotator-for-clinical-data/v1');
-const core = require('ibm-cloud-sdk-core');
-const { BearerTokenAuthenticator } = core;
-
-const acdService = new AnnotatorForClinicalDataAcdV1({
-  version: '{version}',
-  authenticator: new BearerTokenAuthenticator({
-    bearerToken: '{token}'
-    }),
-  serviceUrl: '{url}',
-  disableSslVerification: true,
-});
-```
-
-### Go SDK
-
-#### Authentication
-
-```
-import (
-  "github.com/IBM/go-sdk-core/core"
-  "github.com/IBM/whcs-go-sdk/annotatorforclinicaldataacdv1"
-)
-
-func main() {
-  ACD, err = annotatorforclinicaldataacdv1.NewAnnotatorForClinicalDataAcdV1(&annotatorforclinicaldataacdv1.AnnotatorForClinicalDataAcdV1Options{
-                URL:     "{url}",
-                Version: core.StringPtr("{version}"),
-                Authenticator: &core.BearerTokenAuthenticator{
-                    BearerToken:                 "{token}",
-        },
-    })
-  if err != nil {
-    panic(err)
-  }
-}
-```
-
-#### Authentication and Disabling SSL Verification (not recommended)
-
-```
-import (
-  "github.com/IBM/go-sdk-core/core"
-  "github.com/IBM/whcs-go-sdk/annotatorforclinicaldataacdv1"
-)
-
-func main() {
-  ACD, err = annotatorforclinicaldataacdv1.NewAnnotatorForClinicalDataAcdV1(&annotatorforclinicaldataacdv1.AnnotatorForClinicalDataAcdV1Options{
-                URL:     "{url}",
-                Version: core.StringPtr("{version}"),
-                Authenticator: &core.BearerTokenAuthenticator{
-                    BearerToken:                 "{token}",
-        },
-    })
-  if err != nil {
-    panic(err)
-  }
-  ACD.DisableSSLVerification()
-}
 ```


### PR DESCRIPTION
With these updates, also drop Node and Go SDK refs.