### PR TITLE
Cagrev

### DIFF
--- a/src/pages/installing/air-gap-installation.md
+++ b/src/pages/installing/air-gap-installation.md
@@ -75,7 +75,7 @@ Log into the Red Hat OpenShift Container Platform cluster as a cluster administr
        --case $HOME/offline/<case-file> \
        --inventory clinicalDataAnnotatorOperatorSetup \
        --action configure-creds-airgap \
-       --args "--registry icr.io --user <registry-user> --pass <registry-password>" \
+       --args "--registry cp.icr.io --user <registry-user> --pass <registry-password>" \
    ```
 
    - `<case-file>` is the CASE file.
@@ -212,7 +212,7 @@ Ensure you have the following installed on the portable host:
        --case $HOME/offline/<case-file> \
        --inventory clinicalDataAnnotatorOperatorSetup \
        --action configure-creds-airgap \
-       --args "--registry icr.io --user <registry-user> --pass <registry-password>" \
+       --args "--registry cp.icr.io --user <registry-user> --pass <registry-password>" \
    ```
 
    - `<case-file>` is the CASE file.

--- a/src/pages/installing/installing.md
+++ b/src/pages/installing/installing.md
@@ -36,7 +36,7 @@ Before setting up the pull secret, verify the entitlement key can access the ent
 Example (Docker with IBM Entitled Registry entitlement key):
 
 ```
-docker login -u cp -p <entitlement key> icr.io
+docker login -u cp -p <entitlement key> cp.icr.io
 ```
 
 ## Air-gapped (disconnected) installation
@@ -69,7 +69,7 @@ To add the pull secret to the Openshift global pull secret:
 1. Edit the .dockerconfigjson file and **ADD** a new JSON object to the exiting auths object with the credentials for the entitled registry. For example:
 
    ```
-   "icr.io": {
+   "cp.icr.io": {
        "auth": "aWFtYXBpaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxcGFzc3dvcmQ=",
        "email": "xxx@nomail.relay.ibm.com"
    }
@@ -94,8 +94,8 @@ To add the pull secret to individual ACD operand service accounts:
 1. Create a secret
 
    ```
-   kubectl create secret docker-registry icr.io \
-       --docker-server=icr.io \
+   kubectl create secret docker-registry cp.icr.io \
+       --docker-server=cp.icr.io \
        --docker-username=<username> \
        --docker-password=<password> \
        --docker-email=<email_address> \
@@ -110,7 +110,7 @@ To add the pull secret to individual ACD operand service accounts:
    ```
    kubectl patch serviceaccount ibm-wh-acd-operand \
        --namespace <namespace> \
-       --patch '{"imagePullSecrets": [{"name": "icr.io"}]}'
+       --patch '{"imagePullSecrets": [{"name": "cp.icr.io"}]}'
    ```
 
 1. Then the ACD operand pods must be restarted

--- a/src/pages/troubleshooting/troubleshooting-pull-secrets.md
+++ b/src/pages/troubleshooting/troubleshooting-pull-secrets.md
@@ -14,6 +14,6 @@ If the IBM Entitled Registry pull secret is not configured correctly, ACD operan
 
 1. Reboot and/or replace the cluster's nodes. Updating the global pull secret should reboot all the cluster's nodes, however depending on cluster modifications this rebooting may not occur. Manually rebooting or even replacing nodes may be required to pickup the changes. Ensure the changes are rolled out to every node since other policies, such as a PodDisruptionBudget policy, may prevent a complete rollout and necessitate manual updates.
 
-1. If attempting to use the global pull secret, ensure the distribution supports this. Openshift extends the Kubernetes support to provide a global pull secret. [Verify](/installing/installing/#ibm-entitled-registry-pull-secret) the global pull secret includes the `icr.io` authorization.
+1. If attempting to use the global pull secret, ensure the distribution supports this. Openshift extends the Kubernetes support to provide a global pull secret. [Verify](/installing/installing/#ibm-entitled-registry-pull-secret) the global pull secret includes the `cp.icr.io` authorization.
 
 1. If pull secrets are being configured at the service account level, ensure the ACD operand service account "ibm-wh-acd-operand" is [patched](/installing/installing/#ibm-entitled-registry-pull-secret) to contain the pull secret. This service account is created as part of each ACD instance and namespace scoped.


### PR DESCRIPTION
Updates to reverse the change to move to icr.io and go back to using the cp.icr.io domain for instructions on creating pull secrets, etc.